### PR TITLE
Add syntax highlighting to Usage section in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm i raml2obj --save
 
 
 ## Usage
-```
+```js
 var raml2obj = require('raml2obj');
 
 // source can either be a filename, url, file contents (string) or parsed RAML object.


### PR DESCRIPTION
The [**Usage** section in the README](https://github.com/raml2html/raml2obj/blob/master/README.md#usage) doesn't have syntax highlighting for its example.