### PR TITLE
Update RAML parser to last version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "datatype-expansion": "0.0.12",
-    "raml-1-parser": "1.1.5"
+    "raml-1-parser": "1.1.6"
   },
   "devDependencies": {
     "eslint": "3.7.x",


### PR DESCRIPTION
I use the `raml2html` package that use `raml2obj` to generate HTML
documentation from RAML specification files.

Using the `1.1.5` version leads sometimes to this error:
https://github.com/raml-org/raml-js-parser-2/issues/485

Bumping to `1.1.6` solves the issue.