### PR TITLE
Fix response headers being rendered incorrectly

### DIFF
--- a/consistency-helpers.js
+++ b/consistency-helpers.js
@@ -39,6 +39,16 @@ function makeConsistent(obj, types) {
       delete obj.securedBy;
     }
 
+    // Fix inconsistency between request headers and response headers from raml-1-parser.
+    // https://github.com/raml-org/raml-js-parser-2/issues/582
+    if (Array.isArray(obj.headers)) {
+      obj.headers.forEach((hdr) => {
+        if (typeof hdr.key === 'undefined' && hdr.name) {
+          hdr.key = hdr.name;
+        }
+      });
+    }
+
     Object.keys(obj).forEach((key) => {
       const value = obj[key];
       makeConsistent(value, types);

--- a/test/consistent-headers.raml
+++ b/test/consistent-headers.raml
@@ -1,0 +1,12 @@
+#%RAML 1.0
+title: Consistent Headers
+
+
+/A:
+    get:
+        headers:
+            X-Some-Header: string
+        responses:
+            200:
+                headers:
+                    X-Some-Other-Header: string

--- a/test/consistent-headers.spec.js
+++ b/test/consistent-headers.spec.js
@@ -1,0 +1,26 @@
+/* eslint-env node, mocha */
+
+'use strict';
+
+const raml2obj = require('..');
+const assert = require('assert');
+
+describe('raml2obj', () => {
+  describe('consistent-headers.raml', () => {
+    let obj;
+
+    before((done) => {
+      raml2obj.parse('test/consistent-headers.raml').then((result) => {
+        obj = result;
+        done();
+      }, (error) => {
+        console.log('error', error);
+      });
+    });
+
+    it('should have keys on both request and response headers', () => {
+      assert.strictEqual(obj.resources[0].methods[0].headers[0].key, 'X-Some-Header');
+      assert.strictEqual(obj.resources[0].methods[0].responses[0].headers[0].key, 'X-Some-Other-Header');
+    });
+  });
+});


### PR DESCRIPTION
Happy new year @kevinrenskers!

Fixes https://github.com/raml2html/raml2html/issues/287

This issue is caused by an inconsistency between how request headers and response headers are emitted from `raml-1-parser`. That inconsistency is documented here: https://github.com/raml-org/raml-js-parser-2/issues/582

I did spend half a day trying to solve that inconsistency upstream in the parser - but the cause was not obvious to me in the brief time I had available.

For now, this PR simply makes raml2obj compatible with that inconsistency. It should also play nicely if they get around to fixing the issue upstream. 

I experimented with putting this code in a few different places in `arrays-objects-helpers`, but my conclusion was this solution was the simplest.