### PR TITLE
Update raml parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "datatype-expansion": "0.0.15",
-    "raml-1-parser": "1.1.9"
+    "raml-1-parser": "1.1.13"
   },
   "devDependencies": {
     "eslint": "3.11.x",


### PR DESCRIPTION
Pulls in the most recent fixes from https://github.com/raml-org/raml-js-parser-2/releases.

What do you think about also change the version to `^1.1.13` with caret?