### PR TITLE
prefer taking examples from higher level items instead of types

### DIFF
--- a/consistency-helpers.js
+++ b/consistency-helpers.js
@@ -27,7 +27,7 @@ function makeConsistent(obj, types) {
         }
 
         if (examples) {
-            mergedObj.examples = examples;
+          mergedObj.examples = examples;
         }
 
         Object.assign(obj, mergedObj);

--- a/consistency-helpers.js
+++ b/consistency-helpers.js
@@ -18,11 +18,16 @@ function makeConsistent(obj, types) {
       }
 
       if (types && types[obj.type]) {
+        const examples = obj.examples;
         const mergedObj = Object.assign({}, obj, types[obj.type]);
 
         // Every exception of inheritance should be deleted from mergedObj
         if (obj.description && types[obj.type].description) {
           delete mergedObj.description;
+        }
+
+        if (examples) {
+            mergedObj.examples = examples;
         }
 
         Object.assign(obj, mergedObj);

--- a/test/resourceexample.raml
+++ b/test/resourceexample.raml
@@ -1,0 +1,30 @@
+#%RAML 1.0
+title: resource example
+
+types:
+    ResourceExampleType:
+        type: object
+        properties:
+            content: string
+        additionalProperties: false
+        examples:
+            typeExample1: { "content": "typeExample1" }
+            typeExample2: { "content": "typeExample2" }
+
+
+
+/example:
+    get:
+        responses:
+            200:
+                body:
+                    application/json:
+                        type: ResourceExampleType
+            202:
+                body:
+                    application/json:
+                        type: ResourceExampleType
+                        examples:
+                            resourceExample1:  { "content": "resourceExample1" }
+                            resourceExample2:  { "content": "resourceExample2" }
+

--- a/test/resourceexample.spec.js
+++ b/test/resourceexample.spec.js
@@ -1,0 +1,52 @@
+/* eslint-env node, mocha */
+
+'use strict';
+
+const raml2obj = require('..');
+const assert = require('assert');
+
+describe('raml2obj', () => {
+  describe('resourceexample.raml', () => {
+    let obj;
+
+    before(done => {
+      raml2obj.parse('test/resourceexample.raml').then(
+        result => {
+          obj = result;
+          done();
+        },
+        error => {
+          console.log('error', error);
+        }
+      );
+    });
+
+    it('should have examples from types when no examples in resource', () => {
+      const method = obj.resources[0].methods[0];
+      const response = method.responses[0];
+      const examples = response.body[0].examples;
+      assert.strictEqual(response.code, '200');
+      assert.strictEqual(examples.length, 2);
+      assert.deepEqual(examples[0].structuredValue, {
+        content: 'typeExample1',
+      });
+      assert.deepEqual(examples[1].structuredValue, {
+        content: 'typeExample2',
+      });
+    });
+
+    it('should have examples from resources when given', () => {
+      const method = obj.resources[0].methods[0];
+      const response = method.responses[1];
+      const examples = response.body[0].examples;
+      assert.strictEqual(response.code, '202');
+      assert.strictEqual(examples.length, 2);
+      assert.deepEqual(examples[0].structuredValue, {
+        content: 'resourceExample1',
+      });
+      assert.deepEqual(examples[1].structuredValue, {
+        content: 'resourceExample2',
+      });
+    });
+  });
+});


### PR DESCRIPTION
This solves #36 at least for my use case where I have examples for responses and examples for types. With this change, the examples defined for responses overwrite the examples defined for types