### PR TITLE
Make the type canonicalization failure logging more friendly

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,7 +80,9 @@ function _expandRootTypes(types) {
       types[key] = canonical;
     } catch (err) {
       // Dump the error to stderr and continue with the non-canonical form
-      console.error(err);
+      console.error(
+        'Warning: Unable to canonicalize type "' + key + '": ' + err.message
+      );
     }
   });
 


### PR DESCRIPTION
Clearly indicate that the exception is just a warning
Include the name of the type
Omit the stack trace (since it probably doesn't help most people)