### PR TITLE
Upgrade to datatype-expansion 0.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -342,9 +342,9 @@
       }
     },
     "datatype-expansion": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/datatype-expansion/-/datatype-expansion-0.2.4.tgz",
-      "integrity": "sha512-96ojvKtPz/4l7DXOZiXjyZJyYzViagUNglVRWrMPx+1TQWJh+8ucbulv5PcVsqoBW5dww9MdaTd9mrM2lxokyw==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/datatype-expansion/-/datatype-expansion-0.2.6.tgz",
+      "integrity": "sha512-m0iKih/x56vgo8k70M/sR1XsMZ1PtxW2lnkaxXZDLIoMk2ZrKUzHCccT6imUzIbLuphC8lMBRVeCDYsqjKJlwg==",
       "requires": {
         "lodash": "4.17.4"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/raml2html/raml2obj/issues"
   },
   "dependencies": {
-    "datatype-expansion": "0.2.4",
+    "datatype-expansion": "0.2.6",
     "raml-1-parser": "1.1.31"
   },
   "devDependencies": {


### PR DESCRIPTION
Not yet disabling hoisting of unions because raml2html-default-theme doesn't support it.