### PR TITLE
Update datatype-expansion to 0.3.x

### DIFF
--- a/consistency-helpers.js
+++ b/consistency-helpers.js
@@ -4,6 +4,7 @@ function _isObject(obj) {
 
 function makeConsistent(obj, types) {
   if (_isObject(obj)) {
+    const ignoredKeys = { rawType: true };
     if (obj.type) {
       if (Array.isArray(obj.type)) {
         obj.type = obj.type[0];
@@ -31,11 +32,13 @@ function makeConsistent(obj, types) {
         }
 
         Object.assign(obj, mergedObj);
+        ignoredKeys.type = true;
       }
     }
 
     if (obj.items && types && types[obj.items]) {
       obj.items = types[obj.items];
+      ignoredKeys.items = true;
     }
 
     if (obj.structuredExample) {
@@ -104,8 +107,10 @@ function makeConsistent(obj, types) {
     }
 
     Object.keys(obj).forEach(key => {
-      const value = obj[key];
-      makeConsistent(value, types);
+      // Don't recurse into types, which have already been canonicalized.
+      if (!(key in ignoredKeys)) {
+        makeConsistent(obj[key], types);
+      }
     });
   } else if (Array.isArray(obj)) {
     obj.forEach(value => {

--- a/consistency-helpers.js
+++ b/consistency-helpers.js
@@ -2,42 +2,8 @@ function _isObject(obj) {
   return obj === Object(obj);
 }
 
-function makeConsistent(obj, types) {
+function makeConsistent(obj) {
   if (_isObject(obj)) {
-    if (obj.type) {
-      if (Array.isArray(obj.type)) {
-        obj.type = obj.type[0];
-      }
-
-      if (
-        obj.type === 'array' &&
-        Array.isArray(obj.items) &&
-        obj.items.length === 1
-      ) {
-        obj.items = obj.items[0];
-      }
-
-      if (types && types[obj.type]) {
-        const examples = obj.examples;
-        const mergedObj = Object.assign({}, obj, types[obj.type]);
-
-        // Every exception of inheritance should be deleted from mergedObj
-        if (obj.description && types[obj.type].description) {
-          delete mergedObj.description;
-        }
-
-        if (examples) {
-          mergedObj.examples = examples;
-        }
-
-        Object.assign(obj, mergedObj);
-      }
-    }
-
-    if (obj.items && types && types[obj.items]) {
-      obj.items = types[obj.items];
-    }
-
     if (obj.structuredExample) {
       if (typeof obj.examples === 'undefined') {
         obj.examples = [];
@@ -103,14 +69,9 @@ function makeConsistent(obj, types) {
       });
     }
 
-    Object.keys(obj).forEach(key => {
-      const value = obj[key];
-      makeConsistent(value, types);
-    });
+    Object.keys(obj).forEach(key => makeConsistent(obj[key]));
   } else if (Array.isArray(obj)) {
-    obj.forEach(value => {
-      makeConsistent(value, types);
-    });
+    obj.forEach(makeConsistent);
   }
 
   return obj;

--- a/index.js
+++ b/index.js
@@ -68,21 +68,18 @@ function _addRaml2htmlProperties(ramlObj, parentUrl, allUriParameters) {
 }
 
 // This uses the datatype-expansion library to expand all the root type to their canonical expanded form
-function _expandRootTypes(types, options) {
+function _expandRootTypes(types) {
   if (!types) {
     return types;
   }
 
-  // Defaults to true for compatibility with existing themes
-  const hoistUnions =
-    typeof options !== 'object' || options.hoistUnions !== false;
   Object.keys(types).forEach(key => {
     try {
       const original = types[key];
       const expanded = tools.expandedForm(original, types, {
         trackOriginalType: true,
       });
-      const canonical = tools.canonicalForm(expanded, { hoistUnions });
+      const canonical = tools.canonicalForm(expanded, { hoistUnions: false });
       // Save a reference to the type as defined in the RAML, so we can differentiate between declared
       // and inherited facets, particularly annotations.
       canonical.rawType = original;
@@ -98,7 +95,7 @@ function _expandRootTypes(types, options) {
   return types;
 }
 
-function _enhanceRamlObj(ramlObj, options) {
+function _enhanceRamlObj(ramlObj) {
   // Some of the structures (like `types`) are an array that hold key/value pairs, which is very annoying to work with.
   // Let's make them into a simple object, this makes it easy to use them for direct lookups.
   //
@@ -114,9 +111,7 @@ function _enhanceRamlObj(ramlObj, options) {
 
   // We want to expand inherited root types, so that later on when we copy type properties into an object,
   // we get the full graph.
-  const types = makeExamplesAndTypesConsistent(
-    _expandRootTypes(ramlObj.types, options)
-  );
+  const types = makeExamplesAndTypesConsistent(_expandRootTypes(ramlObj.types));
   // Delete the types from the ramlObj so it's not processed again later on.
   delete ramlObj.types;
 
@@ -202,6 +197,6 @@ function _sourceToRamlObj(source, options = {}) {
 
 module.exports.parse = function(source, options) {
   return _sourceToRamlObj(source, options).then(ramlObj =>
-    _enhanceRamlObj(ramlObj, options)
+    _enhanceRamlObj(ramlObj)
   );
 };

--- a/index.js
+++ b/index.js
@@ -68,18 +68,21 @@ function _addRaml2htmlProperties(ramlObj, parentUrl, allUriParameters) {
 }
 
 // This uses the datatype-expansion library to expand all the root type to their canonical expanded form
-function _expandRootTypes(types) {
+function _expandRootTypes(types, options) {
   if (!types) {
     return types;
   }
 
+  // Defaults to true for compatibility with existing themes
+  const hoistUnions =
+    typeof options !== 'object' || options.hoistUnions !== false;
   Object.keys(types).forEach(key => {
     try {
       const original = types[key];
       const expanded = tools.expandedForm(original, types, {
         trackOriginalType: true,
       });
-      const canonical = tools.canonicalForm(expanded, { hoistUnions: false });
+      const canonical = tools.canonicalForm(expanded, { hoistUnions });
       // Save a reference to the type as defined in the RAML, so we can differentiate between declared
       // and inherited facets, particularly annotations.
       canonical.rawType = original;
@@ -95,7 +98,7 @@ function _expandRootTypes(types) {
   return types;
 }
 
-function _enhanceRamlObj(ramlObj) {
+function _enhanceRamlObj(ramlObj, options) {
   // Some of the structures (like `types`) are an array that hold key/value pairs, which is very annoying to work with.
   // Let's make them into a simple object, this makes it easy to use them for direct lookups.
   //
@@ -111,7 +114,9 @@ function _enhanceRamlObj(ramlObj) {
 
   // We want to expand inherited root types, so that later on when we copy type properties into an object,
   // we get the full graph.
-  const types = makeExamplesAndTypesConsistent(_expandRootTypes(ramlObj.types));
+  const types = makeExamplesAndTypesConsistent(
+    _expandRootTypes(ramlObj.types, options)
+  );
   // Delete the types from the ramlObj so it's not processed again later on.
   delete ramlObj.types;
 
@@ -144,12 +149,16 @@ function _enhanceRamlObj(ramlObj) {
   return ramlObj;
 }
 
-function _sourceToRamlObj(source, validation) {
+function _sourceToRamlObj(source, options = {}) {
+  // "options" was originally a validation flag
+  if (typeof options === 'boolean') {
+    options = { validate: options };
+  }
   if (typeof source === 'string') {
     if (fs.existsSync(source) || source.indexOf('http') === 0) {
       // Parse as file or url
       return raml
-        .loadApi(source, { rejectOnErrors: !!validation })
+        .loadApi(source, { rejectOnErrors: !!options.validate })
         .then(result => {
           if (result._node._universe._typedVersion === '0.8') {
             throw new Error('_sourceToRamlObj: only RAML 1.0 is supported!');
@@ -188,8 +197,8 @@ function _sourceToRamlObj(source, validation) {
   });
 }
 
-module.exports.parse = function(source, validation) {
-  return _sourceToRamlObj(source, validation).then(ramlObj =>
-    _enhanceRamlObj(ramlObj)
+module.exports.parse = function(source, options) {
+  return _sourceToRamlObj(source, options).then(ramlObj =>
+    _enhanceRamlObj(ramlObj, options)
   );
 };

--- a/index.js
+++ b/index.js
@@ -75,10 +75,14 @@ function _expandRootTypes(types) {
 
   Object.keys(types).forEach(key => {
     try {
-      const expanded = tools.expandedForm(types[key], types, {
+      const original = types[key];
+      const expanded = tools.expandedForm(original, types, {
         trackOriginalType: true,
       });
       const canonical = tools.canonicalForm(expanded, { hoistUnions: false });
+      // Save a reference to the type as defined in the RAML, so we can differentiate between declared
+      // and inherited facets, particularly annotations.
+      canonical.rawType = original;
       types[key] = canonical;
     } catch (err) {
       // Dump the error to stderr and continue with the non-canonical form

--- a/index.js
+++ b/index.js
@@ -107,12 +107,9 @@ function _enhanceRamlObj(ramlObj) {
 
   // We want to expand inherited root types, so that later on when we copy type properties into an object,
   // we get the full graph.
-  // Delete the types from the ramlObj so it's not processed again later on.
   const types = makeExamplesAndTypesConsistent(_expandRootTypes(ramlObj.types));
+  // Delete the types from the ramlObj so it's not processed again later on.
   delete ramlObj.types;
-
-  // Recursibely go over the entire object and make all examples and types consistent.
-  ramlObj = makeExamplesAndTypesConsistent(ramlObj, types);
 
   // Other structures (like `responses`) are an object that hold other wrapped objects.
   // Flatten this to simple (non-wrapped) objects in an array instead,

--- a/index.js
+++ b/index.js
@@ -75,8 +75,10 @@ function _expandRootTypes(types) {
 
   Object.keys(types).forEach(key => {
     try {
-      const expanded = tools.expandedForm(types[key], types);
-      const canonical = tools.canonicalForm(expanded);
+      const expanded = tools.expandedForm(types[key], types, {
+        trackOriginalType: true,
+      });
+      const canonical = tools.canonicalForm(expanded, { hoistUnions: false });
       types[key] = canonical;
     } catch (err) {
       // Dump the error to stderr and continue with the non-canonical form

--- a/index.js
+++ b/index.js
@@ -120,6 +120,9 @@ function _enhanceRamlObj(ramlObj, options) {
   // Delete the types from the ramlObj so it's not processed again later on.
   delete ramlObj.types;
 
+  // Recursively go over the entire object and make all examples and types consistent.
+  ramlObj = makeExamplesAndTypesConsistent(ramlObj, types);
+
   // Other structures (like `responses`) are an object that hold other wrapped objects.
   // Flatten this to simple (non-wrapped) objects in an array instead,
   // this makes it easy to loop over them in raml2html / raml2md.

--- a/package-lock.json
+++ b/package-lock.json
@@ -390,9 +390,9 @@
       }
     },
     "datatype-expansion": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/datatype-expansion/-/datatype-expansion-0.2.6.tgz",
-      "integrity": "sha512-m0iKih/x56vgo8k70M/sR1XsMZ1PtxW2lnkaxXZDLIoMk2ZrKUzHCccT6imUzIbLuphC8lMBRVeCDYsqjKJlwg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/datatype-expansion/-/datatype-expansion-0.3.0.tgz",
+      "integrity": "sha512-PbT4x4ALUa07wW3joKJShk7ZS4Hq2KzheIzYNesy33jRgAQwmADYa6E+hf87QAQCWUYxRV9Mx18jWe7r2ceSMw==",
       "requires": {
         "lodash": "4.17.4"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/raml2html/raml2obj/issues"
   },
   "dependencies": {
-    "datatype-expansion": "0.2.x",
+    "datatype-expansion": "0.3.x",
     "raml-1-parser": "1.1.36"
   },
   "devDependencies": {

--- a/test/worldmusic.spec.js
+++ b/test/worldmusic.spec.js
@@ -276,7 +276,7 @@ describe('raml2obj', () => {
     });
   });
 
-  describe('worldmusic.raml', function() {
+  describe('worldmusic.raml without union hoisting', function() {
     this.timeout(10000);
 
     let obj;

--- a/test/worldmusic.spec.js
+++ b/test/worldmusic.spec.js
@@ -275,4 +275,89 @@ describe('raml2obj', () => {
       );
     });
   });
+
+  describe('worldmusic.raml', function() {
+    this.timeout(10000);
+
+    let obj;
+
+    before(done => {
+      raml2obj.parse('test/worldmusic.raml', { hoistUnions: false }).then(
+        result => {
+          obj = result;
+          done();
+        },
+        error => {
+          console.log(JSON.stringify(error));
+        }
+      );
+    });
+
+    it('should test the /api methods', () => {
+      const methods = obj.resources[0].methods;
+
+      assert.strictEqual(methods.length, 2);
+
+      const get = methods[0];
+
+      assert.strictEqual(get.method, 'get');
+      assert.strictEqual(get.allUriParameters.length, 0);
+      assert.deepEqual(get.securedBy, [{ schemeName: 'custom_scheme' }]);
+
+      assert.strictEqual(get.queryString.name, 'queryString');
+      assert.strictEqual(get.queryString.type, 'object');
+      assert.strictEqual(get.queryString.properties.length, 2);
+      assert.strictEqual(get.queryString.properties[0].name, 'start');
+      assert.strictEqual(get.queryString.properties[0].required, false);
+      assert.strictEqual(get.queryString.properties[0].type, 'number');
+
+      assert.strictEqual(get.queryString.properties[1].name, 'page-size');
+      assert.strictEqual(get.queryString.properties[1].required, false);
+      assert.strictEqual(get.queryString.properties[1].type, 'number');
+
+      const post = methods[1];
+
+      assert.strictEqual(post.method, 'post');
+      assert.strictEqual(post.allUriParameters.length, 0);
+      assert.deepEqual(post.securedBy, [{ schemeName: 'custom_scheme' }]);
+      assert.strictEqual(post.body.length, 1);
+      assert.strictEqual(post.body[0].name, 'RamlDataType');
+      assert.strictEqual(post.body[0].key, 'application/json');
+      assert.strictEqual(post.body[0].type, 'object');
+      assert.strictEqual(post.body[0].properties.length, 14);
+      assert.strictEqual(
+        post.body[0].properties[4].examples[0].value,
+        'very well made'
+      );
+      assert.strictEqual(post.body[0].properties[10].key, 'NilValue');
+      assert.strictEqual(
+        post.body[0].properties[10].properties[1].name,
+        'comment'
+      );
+      assert.strictEqual(
+        post.body[0].properties[10].properties[1].type,
+        'union'
+      );
+      assert.strictEqual(
+        post.body[0].properties[10].properties[1].anyOf[0].type,
+        'string'
+      );
+      assert.strictEqual(
+        post.body[0].properties[10].properties[1].anyOf[1].type,
+        'nil'
+      );
+      assert.strictEqual(post.body[0].properties[11].key, 'CatOrDog');
+      assert.strictEqual(post.body[0].properties[11].type, 'union');
+      assert.strictEqual(post.body[0].properties[11].anyOf[0].type, 'object');
+      assert.strictEqual(
+        post.body[0].properties[11].anyOf[0].originalType,
+        'ApiLib.Cat'
+      );
+      assert.strictEqual(post.body[0].properties[11].anyOf[1].type, 'object');
+      assert.strictEqual(
+        post.body[0].properties[11].anyOf[1].originalType,
+        'ApiLib.Dog'
+      );
+    });
+  });
 });

--- a/test/worldmusic.spec.js
+++ b/test/worldmusic.spec.js
@@ -111,41 +111,41 @@ describe('raml2obj', () => {
       assert.strictEqual(post.body.length, 1);
       assert.strictEqual(post.body[0].name, 'RamlDataType');
       assert.strictEqual(post.body[0].key, 'application/json');
-      assert.strictEqual(post.body[0].type, 'union');
-      assert.strictEqual(post.body[0].anyOf.length, 4);
-      assert.strictEqual(post.body[0].anyOf[0].properties.length, 14);
+      assert.strictEqual(post.body[0].type, 'object');
+      assert.strictEqual(post.body[0].properties.length, 14);
       assert.strictEqual(
-        post.body[0].anyOf[0].properties[4].examples[0].value,
+        post.body[0].properties[4].examples[0].value,
         'very well made'
       );
-      assert.strictEqual(post.body[0].anyOf[0].properties[10].key, 'NilValue');
+      assert.strictEqual(post.body[0].properties[10].key, 'NilValue');
       assert.strictEqual(
-        post.body[0].anyOf[0].properties[10].properties[1].type,
+        post.body[0].properties[10].properties[1].name,
+        'comment'
+      );
+      assert.strictEqual(
+        post.body[0].properties[10].properties[1].type,
+        'union'
+      );
+      assert.strictEqual(
+        post.body[0].properties[10].properties[1].anyOf[0].type,
         'string'
       );
-      assert.strictEqual(post.body[0].anyOf[0].properties[11].key, 'CatOrDog');
-      assert.strictEqual(post.body[0].anyOf[0].properties[11].name, 'Cat');
-      assert.strictEqual(post.body[0].anyOf[1].properties[10].key, 'NilValue');
       assert.strictEqual(
-        post.body[0].anyOf[1].properties[10].properties[1].type,
+        post.body[0].properties[10].properties[1].anyOf[1].type,
         'nil'
       );
-      assert.strictEqual(post.body[0].anyOf[1].properties[11].key, 'CatOrDog');
-      assert.strictEqual(post.body[0].anyOf[1].properties[11].name, 'Cat');
-      assert.strictEqual(post.body[0].anyOf[2].properties[10].key, 'NilValue');
+      assert.strictEqual(post.body[0].properties[11].key, 'CatOrDog');
+      assert.strictEqual(post.body[0].properties[11].type, 'union');
+      assert.strictEqual(post.body[0].properties[11].anyOf[0].type, 'object');
       assert.strictEqual(
-        post.body[0].anyOf[2].properties[10].properties[1].type,
-        'string'
+        post.body[0].properties[11].anyOf[0].originalType,
+        'ApiLib.Cat'
       );
-      assert.strictEqual(post.body[0].anyOf[2].properties[11].key, 'CatOrDog');
-      assert.strictEqual(post.body[0].anyOf[2].properties[11].name, 'Dog');
-      assert.strictEqual(post.body[0].anyOf[3].properties[10].key, 'NilValue');
+      assert.strictEqual(post.body[0].properties[11].anyOf[1].type, 'object');
       assert.strictEqual(
-        post.body[0].anyOf[3].properties[10].properties[1].type,
-        'nil'
+        post.body[0].properties[11].anyOf[1].originalType,
+        'ApiLib.Dog'
       );
-      assert.strictEqual(post.body[0].anyOf[3].properties[11].key, 'CatOrDog');
-      assert.strictEqual(post.body[0].anyOf[3].properties[11].name, 'Dog');
     });
 
     it('should test the /entry resource', () => {
@@ -272,91 +272,6 @@ describe('raml2obj', () => {
           '<?xml version="1.0" encoding="UTF-8"?>'
         ),
         0
-      );
-    });
-  });
-
-  describe('worldmusic.raml without union hoisting', function() {
-    this.timeout(10000);
-
-    let obj;
-
-    before(done => {
-      raml2obj.parse('test/worldmusic.raml', { hoistUnions: false }).then(
-        result => {
-          obj = result;
-          done();
-        },
-        error => {
-          console.log(JSON.stringify(error));
-        }
-      );
-    });
-
-    it('should test the /api methods', () => {
-      const methods = obj.resources[0].methods;
-
-      assert.strictEqual(methods.length, 2);
-
-      const get = methods[0];
-
-      assert.strictEqual(get.method, 'get');
-      assert.strictEqual(get.allUriParameters.length, 0);
-      assert.deepEqual(get.securedBy, [{ schemeName: 'custom_scheme' }]);
-
-      assert.strictEqual(get.queryString.name, 'queryString');
-      assert.strictEqual(get.queryString.type, 'object');
-      assert.strictEqual(get.queryString.properties.length, 2);
-      assert.strictEqual(get.queryString.properties[0].name, 'start');
-      assert.strictEqual(get.queryString.properties[0].required, false);
-      assert.strictEqual(get.queryString.properties[0].type, 'number');
-
-      assert.strictEqual(get.queryString.properties[1].name, 'page-size');
-      assert.strictEqual(get.queryString.properties[1].required, false);
-      assert.strictEqual(get.queryString.properties[1].type, 'number');
-
-      const post = methods[1];
-
-      assert.strictEqual(post.method, 'post');
-      assert.strictEqual(post.allUriParameters.length, 0);
-      assert.deepEqual(post.securedBy, [{ schemeName: 'custom_scheme' }]);
-      assert.strictEqual(post.body.length, 1);
-      assert.strictEqual(post.body[0].name, 'RamlDataType');
-      assert.strictEqual(post.body[0].key, 'application/json');
-      assert.strictEqual(post.body[0].type, 'object');
-      assert.strictEqual(post.body[0].properties.length, 14);
-      assert.strictEqual(
-        post.body[0].properties[4].examples[0].value,
-        'very well made'
-      );
-      assert.strictEqual(post.body[0].properties[10].key, 'NilValue');
-      assert.strictEqual(
-        post.body[0].properties[10].properties[1].name,
-        'comment'
-      );
-      assert.strictEqual(
-        post.body[0].properties[10].properties[1].type,
-        'union'
-      );
-      assert.strictEqual(
-        post.body[0].properties[10].properties[1].anyOf[0].type,
-        'string'
-      );
-      assert.strictEqual(
-        post.body[0].properties[10].properties[1].anyOf[1].type,
-        'nil'
-      );
-      assert.strictEqual(post.body[0].properties[11].key, 'CatOrDog');
-      assert.strictEqual(post.body[0].properties[11].type, 'union');
-      assert.strictEqual(post.body[0].properties[11].anyOf[0].type, 'object');
-      assert.strictEqual(
-        post.body[0].properties[11].anyOf[0].originalType,
-        'ApiLib.Cat'
-      );
-      assert.strictEqual(post.body[0].properties[11].anyOf[1].type, 'object');
-      assert.strictEqual(
-        post.body[0].properties[11].anyOf[1].originalType,
-        'ApiLib.Dog'
       );
     });
   });

--- a/test/worldmusic.spec.js
+++ b/test/worldmusic.spec.js
@@ -111,41 +111,41 @@ describe('raml2obj', () => {
       assert.strictEqual(post.body.length, 1);
       assert.strictEqual(post.body[0].name, 'RamlDataType');
       assert.strictEqual(post.body[0].key, 'application/json');
-      assert.strictEqual(post.body[0].type, 'object');
-      assert.strictEqual(post.body[0].properties.length, 14);
+      assert.strictEqual(post.body[0].type, 'union');
+      assert.strictEqual(post.body[0].anyOf.length, 4);
+      assert.strictEqual(post.body[0].anyOf[0].properties.length, 14);
       assert.strictEqual(
-        post.body[0].properties[4].examples[0].value,
+        post.body[0].anyOf[0].properties[4].examples[0].value,
         'very well made'
       );
-      assert.strictEqual(post.body[0].properties[10].key, 'NilValue');
+      assert.strictEqual(post.body[0].anyOf[0].properties[10].key, 'NilValue');
       assert.strictEqual(
-        post.body[0].properties[10].properties[1].name,
-        'comment'
-      );
-      assert.strictEqual(
-        post.body[0].properties[10].properties[1].type,
-        'union'
-      );
-      assert.strictEqual(
-        post.body[0].properties[10].properties[1].anyOf[0].type,
+        post.body[0].anyOf[0].properties[10].properties[1].type,
         'string'
       );
+      assert.strictEqual(post.body[0].anyOf[0].properties[11].key, 'CatOrDog');
+      assert.strictEqual(post.body[0].anyOf[0].properties[11].name, 'Cat');
+      assert.strictEqual(post.body[0].anyOf[1].properties[10].key, 'NilValue');
       assert.strictEqual(
-        post.body[0].properties[10].properties[1].anyOf[1].type,
+        post.body[0].anyOf[1].properties[10].properties[1].type,
         'nil'
       );
-      assert.strictEqual(post.body[0].properties[11].key, 'CatOrDog');
-      assert.strictEqual(post.body[0].properties[11].type, 'union');
-      assert.strictEqual(post.body[0].properties[11].anyOf[0].type, 'object');
+      assert.strictEqual(post.body[0].anyOf[1].properties[11].key, 'CatOrDog');
+      assert.strictEqual(post.body[0].anyOf[1].properties[11].name, 'Cat');
+      assert.strictEqual(post.body[0].anyOf[2].properties[10].key, 'NilValue');
       assert.strictEqual(
-        post.body[0].properties[11].anyOf[0].originalType,
-        'ApiLib.Cat'
+        post.body[0].anyOf[2].properties[10].properties[1].type,
+        'string'
       );
-      assert.strictEqual(post.body[0].properties[11].anyOf[1].type, 'object');
+      assert.strictEqual(post.body[0].anyOf[2].properties[11].key, 'CatOrDog');
+      assert.strictEqual(post.body[0].anyOf[2].properties[11].name, 'Dog');
+      assert.strictEqual(post.body[0].anyOf[3].properties[10].key, 'NilValue');
       assert.strictEqual(
-        post.body[0].properties[11].anyOf[1].originalType,
-        'ApiLib.Dog'
+        post.body[0].anyOf[3].properties[10].properties[1].type,
+        'nil'
       );
+      assert.strictEqual(post.body[0].anyOf[3].properties[11].key, 'CatOrDog');
+      assert.strictEqual(post.body[0].anyOf[3].properties[11].name, 'Dog');
     });
 
     it('should test the /entry resource', () => {

--- a/test/worldmusic.spec.js
+++ b/test/worldmusic.spec.js
@@ -111,41 +111,41 @@ describe('raml2obj', () => {
       assert.strictEqual(post.body.length, 1);
       assert.strictEqual(post.body[0].name, 'RamlDataType');
       assert.strictEqual(post.body[0].key, 'application/json');
-      assert.strictEqual(post.body[0].type, 'union');
-      assert.strictEqual(post.body[0].anyOf.length, 4);
-      assert.strictEqual(post.body[0].anyOf[0].properties.length, 14);
+      assert.strictEqual(post.body[0].type, 'object');
+      assert.strictEqual(post.body[0].properties.length, 14);
       assert.strictEqual(
-        post.body[0].anyOf[0].properties[4].examples[0].value,
+        post.body[0].properties[4].examples[0].value,
         'very well made'
       );
-      assert.strictEqual(post.body[0].anyOf[0].properties[10].key, 'NilValue');
+      assert.strictEqual(post.body[0].properties[10].key, 'NilValue');
       assert.strictEqual(
-        post.body[0].anyOf[0].properties[10].properties[1].type,
+        post.body[0].properties[10].properties[1].name,
+        'comment'
+      );
+      assert.strictEqual(
+        post.body[0].properties[10].properties[1].type,
+        'union'
+      );
+      assert.strictEqual(
+        post.body[0].properties[10].properties[1].anyOf[0].type,
         'string'
       );
-      assert.strictEqual(post.body[0].anyOf[0].properties[11].key, 'CatOrDog');
-      assert.strictEqual(post.body[0].anyOf[0].properties[11].name, 'Cat');
-      assert.strictEqual(post.body[0].anyOf[1].properties[10].key, 'NilValue');
       assert.strictEqual(
-        post.body[0].anyOf[1].properties[10].properties[1].type,
+        post.body[0].properties[10].properties[1].anyOf[1].type,
         'nil'
       );
-      assert.strictEqual(post.body[0].anyOf[1].properties[11].key, 'CatOrDog');
-      assert.strictEqual(post.body[0].anyOf[1].properties[11].name, 'Cat');
-      assert.strictEqual(post.body[0].anyOf[2].properties[10].key, 'NilValue');
+      assert.strictEqual(post.body[0].properties[11].key, 'CatOrDog');
+      assert.strictEqual(post.body[0].properties[11].type, 'union');
+      assert.strictEqual(post.body[0].properties[11].anyOf[0].type, 'object');
       assert.strictEqual(
-        post.body[0].anyOf[2].properties[10].properties[1].type,
-        'string'
+        post.body[0].properties[11].anyOf[0].originalType,
+        'ApiLib.Cat'
       );
-      assert.strictEqual(post.body[0].anyOf[2].properties[11].key, 'CatOrDog');
-      assert.strictEqual(post.body[0].anyOf[2].properties[11].name, 'Dog');
-      assert.strictEqual(post.body[0].anyOf[3].properties[10].key, 'NilValue');
+      assert.strictEqual(post.body[0].properties[11].anyOf[1].type, 'object');
       assert.strictEqual(
-        post.body[0].anyOf[3].properties[10].properties[1].type,
-        'nil'
+        post.body[0].properties[11].anyOf[1].originalType,
+        'ApiLib.Dog'
       );
-      assert.strictEqual(post.body[0].anyOf[3].properties[11].key, 'CatOrDog');
-      assert.strictEqual(post.body[0].anyOf[3].properties[11].name, 'Dog');
     });
 
     it('should test the /entry resource', () => {


### PR DESCRIPTION
This PR addresses several issues:

- Update datatype-expansion to 0.3.x, which fixes invalid hoisting of unions outside of array items, as well as several other issues
- Enable tracking of original type in datatype-expansion, so that themes can reference base types
- Track `rawType` of canonicalized types, so that themes can distinguish between declared annotations and inherited annotations