### PR TITLE
add extensionsAndOverlays passing

### DIFF
--- a/index.js
+++ b/index.js
@@ -155,8 +155,11 @@ function _sourceToRamlObj(source, options = {}) {
   if (typeof source === 'string') {
     if (fs.existsSync(source) || source.indexOf('http') === 0) {
       // Parse as file or url
+
       return raml
-        .loadApi(source, { rejectOnErrors: !!options.validate })
+        .loadApi(source, options.extensionsAndOverlays || [], {
+          rejectOnErrors: !!options.validate,
+        })
         .then(result => {
           if (result._node._universe._typedVersion === '0.8') {
             throw new Error('_sourceToRamlObj: only RAML 1.0 is supported!');

--- a/index.js
+++ b/index.js
@@ -155,7 +155,6 @@ function _sourceToRamlObj(source, options = {}) {
   if (typeof source === 'string') {
     if (fs.existsSync(source) || source.indexOf('http') === 0) {
       // Parse as file or url
-
       return raml
         .loadApi(source, options.extensionsAndOverlays || [], {
           rejectOnErrors: !!options.validate,


### PR DESCRIPTION
RAML 1.0 have Extensions and Overlays.

raml-js-parser-2 supports this by second parameter of loadApi method https://github.com/raml-org/raml-js-parser-2/blob/master/src/index.ts#L137

raml2html PR that pass this option https://github.com/raml2html/raml2html/pull/396