### PR TITLE
Add support to RAML parser resolvers options

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,6 +158,8 @@ function _sourceToRamlObj(source, options = {}) {
       return raml
         .loadApi(source, options.extensionsAndOverlays || [], {
           rejectOnErrors: !!options.validate,
+          httpResolver: options.httpResolver,
+          fsResolver: options.fsResolver,
         })
         .then(result => {
           if (result._node._universe._typedVersion === '0.8') {


### PR DESCRIPTION
Required to fix [raml2html#394](https://github.com/raml2html/raml2html/issues/394)