### PR TITLE
Allow for 'parse' to accept raw input (e.g. string or Buffer)

### DIFF
--- a/index.js
+++ b/index.js
@@ -201,11 +201,31 @@ function _sourceToRamlObj(source, options = {}) {
           fsResolver: options.fsResolver,
         })
         .then(_validateLoadedRaml);
+    } else if (source) {
+      return raml
+        .parseRAML(source, {
+          rejectOnErrors: !!options.validate,
+          httpResolver: options.httpResolver,
+          fsResolver: options.fsResolver,
+        })
+        .then(_validateLoadedRaml);
     }
 
     return new Promise((resolve, reject) => {
-      reject(new Error('_sourceToRamlObj: source does not exist.'));
+      reject(
+        new Error(
+          '_sourceToRamlObj: source does not exist or cannot be parsed.'
+        )
+      );
     });
+  } else if (source instanceof Buffer) {
+    return raml
+      .parseRAML(source.toString(), {
+        rejectOnErrors: !!options.validate,
+        httpResolver: options.httpResolver,
+        fsResolver: options.fsResolver,
+      })
+      .then(_validateLoadedRaml);
   } else if (typeof source === 'object') {
     // Parse RAML object directly
     return new Promise(resolve => {

--- a/index.js
+++ b/index.js
@@ -168,6 +168,24 @@ function _enhanceRamlObj(ramlObj, options) {
   return ramlObj;
 }
 
+function _validateLoadedRaml(ramlObj) {
+  if (ramlObj._node._universe._typedVersion === '0.8') {
+    throw new Error('_sourceToRamlObj: only RAML 1.0 is supported!');
+  }
+
+  if (ramlObj.expand) {
+    return ramlObj.expand(true).toJSON({ serializeMetadata: false });
+  }
+
+  return new Promise((resolve, reject) => {
+    reject(
+      new Error(
+        '_sourceToRamlObj: source could not be parsed. Is it a root RAML file?'
+      )
+    );
+  });
+}
+
 function _sourceToRamlObj(source, options = {}) {
   // "options" was originally a validation flag
   if (typeof options === 'boolean') {
@@ -182,23 +200,7 @@ function _sourceToRamlObj(source, options = {}) {
           httpResolver: options.httpResolver,
           fsResolver: options.fsResolver,
         })
-        .then(result => {
-          if (result._node._universe._typedVersion === '0.8') {
-            throw new Error('_sourceToRamlObj: only RAML 1.0 is supported!');
-          }
-
-          if (result.expand) {
-            return result.expand(true).toJSON({ serializeMetadata: false });
-          }
-
-          return new Promise((resolve, reject) => {
-            reject(
-              new Error(
-                '_sourceToRamlObj: source could not be parsed. Is it a root RAML file?'
-              )
-            );
-          });
-        });
+        .then(_validateLoadedRaml);
     }
 
     return new Promise((resolve, reject) => {

--- a/test/helloworld-as-buffer.spec.js
+++ b/test/helloworld-as-buffer.spec.js
@@ -1,0 +1,107 @@
+/* eslint-env node, mocha */
+
+'use strict';
+
+const raml2obj = require('..');
+const assert = require('assert');
+const fs = require('fs');
+
+describe('raml2obj', () => {
+  describe('helloworld.raml as Buffer', () => {
+    let obj;
+
+    before(done => {
+      const strContent = fs.readFileSync('test/helloworld.raml');
+      raml2obj.parse(strContent).then(
+        result => {
+          obj = result;
+          done();
+        },
+        error => {
+          console.log('error', error);
+        }
+      );
+    });
+
+    it('should test the basic properties of the raml object', () => {
+      assert.strictEqual(obj.title, 'Hello world');
+      assert.strictEqual(obj.version, '1');
+      assert.strictEqual(obj.baseUri, 'http://example.com/{version}');
+      assert.strictEqual(obj.resources.length, 1);
+    });
+
+    it('should test the documentation', () => {
+      assert.strictEqual(obj.documentation.length, 2);
+
+      const first = obj.documentation[0];
+      const second = obj.documentation[1];
+
+      assert.strictEqual(first.title, 'Welcome');
+      assert.strictEqual(
+        first.content,
+        'Welcome to the Example Documentation. The Example API allows you\nto do stuff. See also [example.com](https://www.example.com).\n'
+      );
+      assert.strictEqual(first.uniqueId, 'welcome');
+
+      assert.strictEqual(second.title, 'Chapter two');
+      assert.strictEqual(
+        second.content,
+        'More content here. Including **bold** text!\n'
+      );
+      assert.strictEqual(second.uniqueId, 'chapter_two');
+    });
+
+    it('should test the top level /helloworld resource', () => {
+      const resource = obj.resources[0];
+
+      assert.strictEqual(resource.relativeUri, '/helloworld');
+      assert.strictEqual(resource.displayName, '/helloworld');
+      assert.strictEqual(
+        resource.description,
+        'This is the top level description for /helloworld.'
+      );
+      assert.strictEqual(resource.parentUrl, '');
+      assert.strictEqual(resource.uniqueId, 'helloworld');
+      assert.deepEqual(resource.allUriParameters, []);
+    });
+
+    it('should test the /helloworld methods', () => {
+      const methods = obj.resources[0].methods;
+
+      assert.strictEqual(methods.length, 1);
+
+      const method = methods[0];
+
+      assert.strictEqual(method.method, 'get');
+      assert.deepEqual(method.allUriParameters, []);
+      assert.deepEqual(method.responses.length, 1);
+
+      const response = method.responses[0];
+
+      assert.strictEqual(response.code, '200');
+      assert.strictEqual(response.body.length, 1);
+      assert.strictEqual(response.body[0].name, 'application/json');
+      assert.strictEqual(response.body[0].displayName, 'application/json');
+      assert.strictEqual(
+        response.body[0].type,
+        '{\n  "title": "Hello world Response",\n  "type": "object",\n  "properties": {\n    "message": {\n      "type": "string"\n    }\n  }\n}\n'
+      );
+      assert.strictEqual(
+        response.body[0].examples[0].value,
+        '{\n  "message": "Hello world"\n}'
+      );
+    });
+
+    it('should test the sub-resource', () => {
+      const topTesource = obj.resources[0];
+      assert.strictEqual(topTesource.resources.length, 1);
+
+      const resource = obj.resources[0].resources[0];
+      assert.strictEqual(resource.relativeUri, '/test');
+      assert.strictEqual(resource.displayName, 'TEST');
+      assert.strictEqual(resource.parentUrl, '/helloworld');
+      assert.strictEqual(resource.uniqueId, 'helloworld_test');
+      assert.deepEqual(resource.allUriParameters, []);
+    });
+  });
+});

--- a/test/helloworld-as-string.spec.js
+++ b/test/helloworld-as-string.spec.js
@@ -1,0 +1,107 @@
+/* eslint-env node, mocha */
+
+'use strict';
+
+const raml2obj = require('..');
+const assert = require('assert');
+const fs = require('fs');
+
+describe('raml2obj', () => {
+  describe('helloworld.raml as string', () => {
+    let obj;
+
+    before(done => {
+      const strContent = fs.readFileSync('test/helloworld.raml').toString();
+      raml2obj.parse(strContent).then(
+        result => {
+          obj = result;
+          done();
+        },
+        error => {
+          console.log('error', error);
+        }
+      );
+    });
+
+    it('should test the basic properties of the raml object', () => {
+      assert.strictEqual(obj.title, 'Hello world');
+      assert.strictEqual(obj.version, '1');
+      assert.strictEqual(obj.baseUri, 'http://example.com/{version}');
+      assert.strictEqual(obj.resources.length, 1);
+    });
+
+    it('should test the documentation', () => {
+      assert.strictEqual(obj.documentation.length, 2);
+
+      const first = obj.documentation[0];
+      const second = obj.documentation[1];
+
+      assert.strictEqual(first.title, 'Welcome');
+      assert.strictEqual(
+        first.content,
+        'Welcome to the Example Documentation. The Example API allows you\nto do stuff. See also [example.com](https://www.example.com).\n'
+      );
+      assert.strictEqual(first.uniqueId, 'welcome');
+
+      assert.strictEqual(second.title, 'Chapter two');
+      assert.strictEqual(
+        second.content,
+        'More content here. Including **bold** text!\n'
+      );
+      assert.strictEqual(second.uniqueId, 'chapter_two');
+    });
+
+    it('should test the top level /helloworld resource', () => {
+      const resource = obj.resources[0];
+
+      assert.strictEqual(resource.relativeUri, '/helloworld');
+      assert.strictEqual(resource.displayName, '/helloworld');
+      assert.strictEqual(
+        resource.description,
+        'This is the top level description for /helloworld.'
+      );
+      assert.strictEqual(resource.parentUrl, '');
+      assert.strictEqual(resource.uniqueId, 'helloworld');
+      assert.deepEqual(resource.allUriParameters, []);
+    });
+
+    it('should test the /helloworld methods', () => {
+      const methods = obj.resources[0].methods;
+
+      assert.strictEqual(methods.length, 1);
+
+      const method = methods[0];
+
+      assert.strictEqual(method.method, 'get');
+      assert.deepEqual(method.allUriParameters, []);
+      assert.deepEqual(method.responses.length, 1);
+
+      const response = method.responses[0];
+
+      assert.strictEqual(response.code, '200');
+      assert.strictEqual(response.body.length, 1);
+      assert.strictEqual(response.body[0].name, 'application/json');
+      assert.strictEqual(response.body[0].displayName, 'application/json');
+      assert.strictEqual(
+        response.body[0].type,
+        '{\n  "title": "Hello world Response",\n  "type": "object",\n  "properties": {\n    "message": {\n      "type": "string"\n    }\n  }\n}\n'
+      );
+      assert.strictEqual(
+        response.body[0].examples[0].value,
+        '{\n  "message": "Hello world"\n}'
+      );
+    });
+
+    it('should test the sub-resource', () => {
+      const topTesource = obj.resources[0];
+      assert.strictEqual(topTesource.resources.length, 1);
+
+      const resource = obj.resources[0].resources[0];
+      assert.strictEqual(resource.relativeUri, '/test');
+      assert.strictEqual(resource.displayName, 'TEST');
+      assert.strictEqual(resource.parentUrl, '/helloworld');
+      assert.strictEqual(resource.uniqueId, 'helloworld_test');
+      assert.deepEqual(resource.allUriParameters, []);
+    });
+  });
+});


### PR DESCRIPTION
I have been working with raml2html recently and found that I am sourcing RAML information from external sources where a URL may not be possible to reference it. However, it can be retrieved as raw content via communication with the source.

I saw that raml-1-parser supports the ability to parse RAML content as a string via 'parseRAML', so raml2obj can call that when it detects that the incoming source in 'parse' is raw content rather than a URL.

As I was writing my initial implementation for this, I am wondering if the use of the URL may be a possible and readable solution after all, but I finished this up under the assumption there are other use cases I am not aware of.

The test cases simply copy 'helloworld' and check that it can still be parsed if it is first read in as a string. Are there any other test cases that should be created to validate this?